### PR TITLE
Add logging and error handling to ETL scripts

### DIFF
--- a/Codes/01_ETL_Operations.py
+++ b/Codes/01_ETL_Operations.py
@@ -2,27 +2,42 @@
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, to_date
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # SparkSession is auto-created in Databricks, but you can include this for standalone PySpark
 spark = SparkSession.builder.appName("Retail_ETL").getOrCreate()
 
 # Bronze ingestion
 csv_path = "/FileStore/tables/superstore.csv"
-raw = (
-    spark.read
-    .option("header", True)
-    .option("inferSchema", True)
-    .csv(csv_path)
-)
+try:
+    raw = spark.read.option("header", True).option("inferSchema", True).csv(csv_path)
+    logger.info("Read CSV successfully from %s", csv_path)
+except Exception as e:
+    logger.error("Failed to read CSV from %s: %s", csv_path, e)
+    raise
 
 # Quick clean for Silver
 df = (
     raw.withColumnRenamed("Order ID", "order_id")
-       .withColumn("order_date", to_date(col("Order Date"), "MM/dd/yyyy"))
-       .withColumn("ship_date",  to_date(col("Ship Date"),  "MM/dd/yyyy"))
-       .dropna(subset=["order_id", "order_date"])
+    .withColumn("order_date", to_date(col("Order Date"), "MM/dd/yyyy"))
+    .withColumn("ship_date", to_date(col("Ship Date"), "MM/dd/yyyy"))
+    .dropna(subset=["order_id", "order_date"])
 )
 
 # Save Bronze & Silver tables
-raw.write.format("delta").mode("overwrite").saveAsTable("bronze.superstore")
-df.write.format("delta").mode("overwrite").saveAsTable("silver.superstore")
+try:
+    raw.write.format("delta").mode("overwrite").saveAsTable("bronze.superstore")
+    logger.info("Bronze table saved to bronze.superstore")
+except Exception as e:
+    logger.error("Failed to write bronze table: %s", e)
+    raise
+
+try:
+    df.write.format("delta").mode("overwrite").saveAsTable("silver.superstore")
+    logger.info("Silver table saved to silver.superstore")
+except Exception as e:
+    logger.error("Failed to write silver table: %s", e)
+    raise

--- a/Codes/02_Delta_Lake_For_Storage.py
+++ b/Codes/02_Delta_Lake_For_Storage.py
@@ -1,17 +1,32 @@
 from pyspark.sql import SparkSession
+import logging
 
 # 02_Delta_Lake_For_Storage (Retail)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 spark = SparkSession.builder.appName("Retail_Delta_Storage").getOrCreate()
 
-silver = spark.table("silver.superstore")
+try:
+    silver = spark.table("silver.superstore")
+    logger.info("Loaded table silver.superstore")
+except Exception as e:
+    logger.error("Failed to load table silver.superstore: %s", e)
+    raise
 
 # partition for scale (pick one: Region or order_date)
-(silver.write
- .format("delta")
- .mode("overwrite")
- .partitionBy("Region")
- .saveAsTable("silver.superstore_partitioned"))
+try:
+    (
+        silver.write.format("delta")
+        .mode("overwrite")
+        .partitionBy("Region")
+        .saveAsTable("silver.superstore_partitioned")
+    )
+    logger.info("Silver table partitioned to silver.superstore_partitioned")
+except Exception as e:
+    logger.error("Failed to write partitioned table: %s", e)
+    raise
 
 # (optional) compaction ops if enabled in your workspace:
 # spark.sql("OPTIMIZE silver.superstore_partitioned ZORDER BY (Category, Region)")
-print("✅ Silver partitioned table created: silver.superstore_partitioned")
+logger.info("Silver partitioned table created: silver.superstore_partitioned")

--- a/Codes/03_Spark_SQL_for_DataTransformations.py
+++ b/Codes/03_Spark_SQL_for_DataTransformations.py
@@ -1,22 +1,41 @@
 # 03_Spark_SQL_For_DataTransformation (Retail → Gold)
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import sum as _sum
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 spark = SparkSession.builder.appName("Retail_Gold_Build").getOrCreate()
 
-silver = spark.table("silver.superstore_partitioned")
+try:
+    silver = spark.table("silver.superstore_partitioned")
+    logger.info("Loaded table silver.superstore_partitioned")
+except Exception as e:
+    logger.error("Failed to load table silver.superstore_partitioned: %s", e)
+    raise
 
-gold = (silver.groupBy("Category","Region")
-              .agg(_sum("Sales").alias("total_sales"),
-                   _sum("Profit").alias("total_profit")))
+gold = silver.groupBy("Category", "Region").agg(
+    _sum("Sales").alias("total_sales"), _sum("Profit").alias("total_profit")
+)
 
-gold.write.format("delta").mode("overwrite").saveAsTable("gold.sales_summary")
+try:
+    gold.write.format("delta").mode("overwrite").saveAsTable("gold.sales_summary")
+    logger.info("Gold table saved to gold.sales_summary")
+except Exception as e:
+    logger.error("Failed to save gold table: %s", e)
+    raise
 
 # sanity check (works in Databricks notebooks)
 try:
     display(spark.table("gold.sales_summary").orderBy("total_sales", ascending=False))
 except NameError:
     # display() not available outside notebook
-    print(spark.table("gold.sales_summary").orderBy("total_sales", ascending=False).limit(10).toPandas())
+    logger.info(
+        spark.table("gold.sales_summary")
+        .orderBy("total_sales", ascending=False)
+        .limit(10)
+        .toPandas()
+    )
 
-print("✅ Gold table created: gold.sales_summary")
+logger.info("Gold table created: gold.sales_summary")

--- a/Codes/04_Visualization_of_Transformed_Data.py
+++ b/Codes/04_Visualization_of_Transformed_Data.py
@@ -9,9 +9,13 @@ Visualization of Gold Layer (Retail ETL Project)
 """
 
 import os
+import logging
 import matplotlib.pyplot as plt
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # Create SparkSession
 spark = SparkSession.builder.appName("Retail_Gold_Visualization").getOrCreate()
@@ -19,47 +23,67 @@ spark = SparkSession.builder.appName("Retail_Gold_Visualization").getOrCreate()
 OUT_DIR = "/dbfs/tmp"
 os.makedirs(OUT_DIR, exist_ok=True)
 
+
 def plot_sales_by_category(df):
     pdf = df.toPandas()
     if pdf.empty or "Category" not in pdf.columns or "total_sales" not in pdf.columns:
         raise ValueError("Missing required columns for Sales by Category")
-    ax = pdf.sort_values("total_sales", ascending=False).plot(kind="bar", x="Category", y="total_sales")
+    ax = pdf.sort_values("total_sales", ascending=False).plot(
+        kind="bar", x="Category", y="total_sales"
+    )
     ax.set_title("Total Sales by Category")
     ax.set_xlabel("Category")
     ax.set_ylabel("Total Sales")
     plt.tight_layout()
     out = f"{OUT_DIR}/total_sales_by_category.png"
-    plt.savefig(out); plt.show()
-    print(f"✅ Saved: {out}")
+    try:
+        plt.savefig(out)
+        plt.show()
+        logger.info("Saved: %s", out)
+    except Exception as e:
+        logger.error("Failed to save sales by category plot: %s", e)
+        raise
+
 
 def plot_profit_by_region(df):
     pdf = df.toPandas()
     if pdf.empty or "Region" not in pdf.columns or "total_profit" not in pdf.columns:
         raise ValueError("Missing required columns for Profit by Region")
-    ax = pdf.sort_values("total_profit", ascending=False).plot(kind="bar", x="Region", y="total_profit")
+    ax = pdf.sort_values("total_profit", ascending=False).plot(
+        kind="bar", x="Region", y="total_profit"
+    )
     ax.set_title("Total Profit by Region")
     ax.set_xlabel("Region")
     ax.set_ylabel("Total Profit")
     plt.tight_layout()
     out = f"{OUT_DIR}/total_profit_by_region.png"
-    plt.savefig(out); plt.show()
-    print(f"✅ Saved: {out}")
+    try:
+        plt.savefig(out)
+        plt.show()
+        logger.info("Saved: %s", out)
+    except Exception as e:
+        logger.error("Failed to save profit by region plot: %s", e)
+        raise
+
 
 try:
     # Query from Gold Layer
-    sales_summary = spark.sql("SELECT Category, Region, total_sales, total_profit FROM gold.sales_summary")
+    sales_summary = spark.sql(
+        "SELECT Category, Region, total_sales, total_profit FROM gold.sales_summary"
+    )
+    logger.info("Loaded data from gold.sales_summary")
 
     # Create two plots
     plot_sales_by_category(sales_summary.select("Category", "total_sales").distinct())
     plot_profit_by_region(sales_summary.select("Region", "total_profit").distinct())
 
-    print("🎉 Visualization complete. Open images via:")
-    print("   /files/tmp/total_sales_by_category.png")
-    print("   /files/tmp/total_profit_by_region.png")
+    logger.info("Visualization complete. Open images via:")
+    logger.info("   /files/tmp/total_sales_by_category.png")
+    logger.info("   /files/tmp/total_profit_by_region.png")
 
 except AnalysisException as e:
-    print(f"SQL query error: {e}")
+    logger.error("SQL query error: %s", e)
 except ValueError as e:
-    print(f"Data validation error: {e}")
+    logger.error("Data validation error: %s", e)
 except Exception as e:
-    print(f"Unexpected error: {e}")
+    logger.error("Unexpected error: %s", e)


### PR DESCRIPTION
## Summary
- add Python logging to ETL scripts
- wrap CSV/table reads and writes in try/except blocks with error logging
- log plot generation steps for visualization

## Testing
- `pytest Codes/Test_main.py` *(fails: AssertionError: assert os.path.exists('01_ETL_Operations.py'))*

------
https://chatgpt.com/codex/tasks/task_e_68a5d82cf6a0832e856a369a1669c5a3