### PR TITLE
Use flake8 for linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ test:
 	python -m pytest \Codes/Test_*.py
 
 lint:
-	pylint \Codes/main.py
+	flake8 Codes/
 
 all: install format lint test


### PR DESCRIPTION
## Summary
- switch Makefile lint target to run `flake8` across Codes/

## Testing
- `make lint` *(fails: E501 line too long, E231 missing whitespace, E302 expected 2 blank lines, etc.)*
- `pytest Codes/Test_*.py` *(fails: AssertionError: assert False)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d82b441c832eb0faab71ce41b42d