### PR TITLE
Add ETL helper and restructure tests

### DIFF
--- a/Codes/Test_main.py
+++ b/Codes/Test_main.py
@@ -1,8 +1,0 @@
-import os
-
-def test_repo_layout():
-    assert os.path.exists("README.md")
-    assert os.path.exists("01_ETL_Operations.py")
-    assert os.path.exists("02_Delta_Lake_For_Storage.py")
-    assert os.path.exists("03_Spark_SQL_for_DataTransformations.py")
-    assert os.path.exists("04_Visualization_of_Transformed_Data.py")

--- a/Codes/etl.py
+++ b/Codes/etl.py
@@ -1,0 +1,12 @@
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import col, to_date
+
+
+def run_etl(df: DataFrame) -> DataFrame:
+    """Perform a minimal ETL transformation on the given DataFrame."""
+    return (
+        df.withColumnRenamed("Order ID", "order_id")
+        .withColumn("order_date", to_date(col("Order Date"), "MM/dd/yyyy"))
+        .withColumn("ship_date", to_date(col("Ship Date"), "MM/dd/yyyy"))
+        .drop("Order Date", "Ship Date")
+    )

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ format:
 	black \Codes/*.py 
 
 test:
-	python -m pytest \Codes/Test_*.py
+python -m pytest tests
 
 lint:
 	pylint \Codes/main.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from pyspark.sql import SparkSession
+
+
+@pytest.fixture(scope="session")
+def spark():
+    spark = SparkSession.builder.master("local[*]").appName("tests").getOrCreate()
+    yield spark
+    spark.stop()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from Codes.etl import run_etl
+
+
+def test_repo_layout():
+    assert os.path.exists("README.md")
+    assert os.path.exists("Codes/01_ETL_Operations.py")
+    assert os.path.exists("Codes/02_Delta_Lake_For_Storage.py")
+    assert os.path.exists("Codes/03_Spark_SQL_for_DataTransformations.py")
+    assert os.path.exists("Codes/04_Visualization_of_Transformed_Data.py")
+
+
+def test_run_etl(spark):
+    data = [("CA-2016-152156", "11/08/2016", "11/11/2016")]
+    df = spark.createDataFrame(data, ["Order ID", "Order Date", "Ship Date"])
+    result = run_etl(df)
+    assert result.columns == ["order_id", "order_date", "ship_date"]
+    row = result.collect()[0]
+    assert row.order_id == "CA-2016-152156"
+    assert str(row.order_date) == "2016-11-08"


### PR DESCRIPTION
## Summary
- add `run_etl` helper to perform basic transformations
- move tests into `tests/` and cover `run_etl` with a small in-memory DataFrame
- point `make test` to the new test suite

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d82747bc832ea6bb00008c37251e