### PR TITLE
Centralize ETL configuration via config module

### DIFF
--- a/Codes/01_ETL_Operations.py
+++ b/Codes/01_ETL_Operations.py
@@ -2,12 +2,13 @@
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, to_date
+import config
 
 # SparkSession is auto-created in Databricks, but you can include this for standalone PySpark
 spark = SparkSession.builder.appName("Retail_ETL").getOrCreate()
 
 # Bronze ingestion
-csv_path = "/FileStore/tables/superstore.csv"
+csv_path = config.CSV_PATH
 raw = (
     spark.read
     .option("header", True)
@@ -24,5 +25,5 @@ df = (
 )
 
 # Save Bronze & Silver tables
-raw.write.format("delta").mode("overwrite").saveAsTable("bronze.superstore")
-df.write.format("delta").mode("overwrite").saveAsTable("silver.superstore")
+raw.write.format("delta").mode("overwrite").saveAsTable(config.BRONZE_TABLE)
+df.write.format("delta").mode("overwrite").saveAsTable(config.SILVER_TABLE)

--- a/Codes/02_Delta_Lake_For_Storage.py
+++ b/Codes/02_Delta_Lake_For_Storage.py
@@ -1,17 +1,18 @@
 from pyspark.sql import SparkSession
+import config
 
 # 02_Delta_Lake_For_Storage (Retail)
 spark = SparkSession.builder.appName("Retail_Delta_Storage").getOrCreate()
 
-silver = spark.table("silver.superstore")
+silver = spark.table(config.SILVER_TABLE)
 
 # partition for scale (pick one: Region or order_date)
 (silver.write
  .format("delta")
  .mode("overwrite")
  .partitionBy("Region")
- .saveAsTable("silver.superstore_partitioned"))
+ .saveAsTable(config.SILVER_PARTITIONED_TABLE))
 
 # (optional) compaction ops if enabled in your workspace:
-# spark.sql("OPTIMIZE silver.superstore_partitioned ZORDER BY (Category, Region)")
-print("✅ Silver partitioned table created: silver.superstore_partitioned")
+# spark.sql(f"OPTIMIZE {config.SILVER_PARTITIONED_TABLE} ZORDER BY (Category, Region)")
+print(f"✅ Silver partitioned table created: {config.SILVER_PARTITIONED_TABLE}")

--- a/Codes/03_Spark_SQL_for_DataTransformations.py
+++ b/Codes/03_Spark_SQL_for_DataTransformations.py
@@ -1,22 +1,23 @@
 # 03_Spark_SQL_For_DataTransformation (Retail → Gold)
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import sum as _sum
+import config
 
 spark = SparkSession.builder.appName("Retail_Gold_Build").getOrCreate()
 
-silver = spark.table("silver.superstore_partitioned")
+silver = spark.table(config.SILVER_PARTITIONED_TABLE)
 
 gold = (silver.groupBy("Category","Region")
               .agg(_sum("Sales").alias("total_sales"),
                    _sum("Profit").alias("total_profit")))
 
-gold.write.format("delta").mode("overwrite").saveAsTable("gold.sales_summary")
+gold.write.format("delta").mode("overwrite").saveAsTable(config.GOLD_TABLE)
 
 # sanity check (works in Databricks notebooks)
 try:
-    display(spark.table("gold.sales_summary").orderBy("total_sales", ascending=False))
+    display(spark.table(config.GOLD_TABLE).orderBy("total_sales", ascending=False))
 except NameError:
     # display() not available outside notebook
-    print(spark.table("gold.sales_summary").orderBy("total_sales", ascending=False).limit(10).toPandas())
+    print(spark.table(config.GOLD_TABLE).orderBy("total_sales", ascending=False).limit(10).toPandas())
 
-print("✅ Gold table created: gold.sales_summary")
+print(f"✅ Gold table created: {config.GOLD_TABLE}")

--- a/Codes/04_Visualization_of_Transformed_Data.py
+++ b/Codes/04_Visualization_of_Transformed_Data.py
@@ -12,11 +12,12 @@ import os
 import matplotlib.pyplot as plt
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
+import config
 
 # Create SparkSession
 spark = SparkSession.builder.appName("Retail_Gold_Visualization").getOrCreate()
 
-OUT_DIR = "/dbfs/tmp"
+OUT_DIR = config.OUTPUT_DIR
 os.makedirs(OUT_DIR, exist_ok=True)
 
 def plot_sales_by_category(df):
@@ -47,7 +48,9 @@ def plot_profit_by_region(df):
 
 try:
     # Query from Gold Layer
-    sales_summary = spark.sql("SELECT Category, Region, total_sales, total_profit FROM gold.sales_summary")
+    sales_summary = spark.sql(
+        f"SELECT Category, Region, total_sales, total_profit FROM {config.GOLD_TABLE}"
+    )
 
     # Create two plots
     plot_sales_by_category(sales_summary.select("Category", "total_sales").distinct())

--- a/Codes/Test_main.py
+++ b/Codes/Test_main.py
@@ -1,8 +1,16 @@
 import os
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+CODES_DIR = ROOT_DIR / "Codes"
+
 
 def test_repo_layout():
-    assert os.path.exists("README.md")
-    assert os.path.exists("01_ETL_Operations.py")
-    assert os.path.exists("02_Delta_Lake_For_Storage.py")
-    assert os.path.exists("03_Spark_SQL_for_DataTransformations.py")
-    assert os.path.exists("04_Visualization_of_Transformed_Data.py")
+    assert (ROOT_DIR / "README.md").exists()
+    for fname in [
+        "01_ETL_Operations.py",
+        "02_Delta_Lake_For_Storage.py",
+        "03_Spark_SQL_for_DataTransformations.py",
+        "04_Visualization_of_Transformed_Data.py",
+    ]:
+        assert (CODES_DIR / fname).exists()

--- a/Codes/config.py
+++ b/Codes/config.py
@@ -1,0 +1,8 @@
+import os
+
+CSV_PATH = os.getenv("CSV_PATH", "/FileStore/tables/superstore.csv")
+BRONZE_TABLE = os.getenv("BRONZE_TABLE", "bronze.superstore")
+SILVER_TABLE = os.getenv("SILVER_TABLE", "silver.superstore")
+SILVER_PARTITIONED_TABLE = os.getenv("SILVER_PARTITIONED_TABLE", "silver.superstore_partitioned")
+GOLD_TABLE = os.getenv("GOLD_TABLE", "gold.sales_summary")
+OUTPUT_DIR = os.getenv("OUTPUT_DIR", "/dbfs/tmp")


### PR DESCRIPTION
## Summary
- add `Codes/config.py` for CSV path, Delta table names, and output dir with env overrides
- refactor ETL scripts to pull settings from the new configuration
- adjust repo layout test to use repository-relative paths

## Testing
- `pytest Codes/Test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5d82438e0832e88a095e01e066828