### PR TITLE
Refactor ETL scripts into reusable functions

### DIFF
--- a/Codes/01_ETL_Operations.py
+++ b/Codes/01_ETL_Operations.py
@@ -3,26 +3,32 @@
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, to_date
 
-# SparkSession is auto-created in Databricks, but you can include this for standalone PySpark
-spark = SparkSession.builder.appName("Retail_ETL").getOrCreate()
 
-# Bronze ingestion
-csv_path = "/FileStore/tables/superstore.csv"
-raw = (
-    spark.read
-    .option("header", True)
-    .option("inferSchema", True)
-    .csv(csv_path)
-)
+def run_etl_operations(
+    spark: SparkSession,
+    csv_path: str,
+    bronze_table: str,
+    silver_table: str,
+) -> None:
+    """Ingest raw data and write Bronze/Silver Delta tables."""
+    raw = spark.read.option("header", True).option("inferSchema", True).csv(csv_path)
 
-# Quick clean for Silver
-df = (
-    raw.withColumnRenamed("Order ID", "order_id")
-       .withColumn("order_date", to_date(col("Order Date"), "MM/dd/yyyy"))
-       .withColumn("ship_date",  to_date(col("Ship Date"),  "MM/dd/yyyy"))
-       .dropna(subset=["order_id", "order_date"])
-)
+    df = (
+        raw.withColumnRenamed("Order ID", "order_id")
+        .withColumn("order_date", to_date(col("Order Date"), "MM/dd/yyyy"))
+        .withColumn("ship_date", to_date(col("Ship Date"), "MM/dd/yyyy"))
+        .dropna(subset=["order_id", "order_date"])
+    )
 
-# Save Bronze & Silver tables
-raw.write.format("delta").mode("overwrite").saveAsTable("bronze.superstore")
-df.write.format("delta").mode("overwrite").saveAsTable("silver.superstore")
+    raw.write.format("delta").mode("overwrite").saveAsTable(bronze_table)
+    df.write.format("delta").mode("overwrite").saveAsTable(silver_table)
+
+
+if __name__ == "__main__":
+    spark = SparkSession.builder.appName("Retail_ETL").getOrCreate()
+    run_etl_operations(
+        spark,
+        csv_path="/FileStore/tables/superstore.csv",
+        bronze_table="bronze.superstore",
+        silver_table="silver.superstore",
+    )

--- a/Codes/02_Delta_Lake_For_Storage.py
+++ b/Codes/02_Delta_Lake_For_Storage.py
@@ -1,17 +1,32 @@
 from pyspark.sql import SparkSession
 
-# 02_Delta_Lake_For_Storage (Retail)
-spark = SparkSession.builder.appName("Retail_Delta_Storage").getOrCreate()
 
-silver = spark.table("silver.superstore")
+def delta_lake_for_storage(
+    spark: SparkSession,
+    source_table: str,
+    target_table: str,
+    partition_column: str,
+) -> None:
+    """Partition and store data in Delta Lake."""
+    silver = spark.table(source_table)
 
-# partition for scale (pick one: Region or order_date)
-(silver.write
- .format("delta")
- .mode("overwrite")
- .partitionBy("Region")
- .saveAsTable("silver.superstore_partitioned"))
+    (
+        silver.write.format("delta")
+        .mode("overwrite")
+        .partitionBy(partition_column)
+        .saveAsTable(target_table)
+    )
 
-# (optional) compaction ops if enabled in your workspace:
-# spark.sql("OPTIMIZE silver.superstore_partitioned ZORDER BY (Category, Region)")
-print("✅ Silver partitioned table created: silver.superstore_partitioned")
+    # (optional) compaction ops if enabled in your workspace:
+    # spark.sql(f"OPTIMIZE {target_table} ZORDER BY (Category, Region)")
+    print(f"✅ Silver partitioned table created: {target_table}")
+
+
+if __name__ == "__main__":
+    spark = SparkSession.builder.appName("Retail_Delta_Storage").getOrCreate()
+    delta_lake_for_storage(
+        spark,
+        source_table="silver.superstore",
+        target_table="silver.superstore_partitioned",
+        partition_column="Region",
+    )

--- a/Codes/03_Spark_SQL_for_DataTransformations.py
+++ b/Codes/03_Spark_SQL_for_DataTransformations.py
@@ -1,22 +1,43 @@
-# 03_Spark_SQL_For_DataTransformation (Retail → Gold)
+"""Build the Gold layer using Spark SQL transformations."""
+
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import sum as _sum
 
-spark = SparkSession.builder.appName("Retail_Gold_Build").getOrCreate()
 
-silver = spark.table("silver.superstore_partitioned")
+def transform_to_gold(
+    spark: SparkSession,
+    source_table: str,
+    target_table: str,
+) -> None:
+    """Aggregate Silver data and persist a Gold table."""
+    silver = spark.table(source_table)
 
-gold = (silver.groupBy("Category","Region")
-              .agg(_sum("Sales").alias("total_sales"),
-                   _sum("Profit").alias("total_profit")))
+    gold = silver.groupBy("Category", "Region").agg(
+        _sum("Sales").alias("total_sales"),
+        _sum("Profit").alias("total_profit"),
+    )
 
-gold.write.format("delta").mode("overwrite").saveAsTable("gold.sales_summary")
+    gold.write.format("delta").mode("overwrite").saveAsTable(target_table)
 
-# sanity check (works in Databricks notebooks)
-try:
-    display(spark.table("gold.sales_summary").orderBy("total_sales", ascending=False))
-except NameError:
-    # display() not available outside notebook
-    print(spark.table("gold.sales_summary").orderBy("total_sales", ascending=False).limit(10).toPandas())
+    # sanity check (works in Databricks notebooks)
+    try:
+        display(spark.table(target_table).orderBy("total_sales", ascending=False))
+    except NameError:
+        # display() not available outside notebook
+        print(
+            spark.table(target_table)
+            .orderBy("total_sales", ascending=False)
+            .limit(10)
+            .toPandas()
+        )
 
-print("✅ Gold table created: gold.sales_summary")
+    print(f"✅ Gold table created: {target_table}")
+
+
+if __name__ == "__main__":
+    spark = SparkSession.builder.appName("Retail_Gold_Build").getOrCreate()
+    transform_to_gold(
+        spark,
+        source_table="silver.superstore_partitioned",
+        target_table="gold.sales_summary",
+    )

--- a/Codes/04_Visualization_of_Transformed_Data.py
+++ b/Codes/04_Visualization_of_Transformed_Data.py
@@ -1,65 +1,81 @@
 # Databricks notebook source
-"""
-Visualization of Gold Layer (Retail ETL Project)
-
-- Reads from gold.sales_summary
-- Creates business-ready plots:
-  1. Total Sales by Category
-  2. Total Profit by Region
-"""
+"""Visualization of Gold Layer (Retail ETL Project)."""
 
 import os
 import matplotlib.pyplot as plt
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
 
-# Create SparkSession
-spark = SparkSession.builder.appName("Retail_Gold_Visualization").getOrCreate()
 
-OUT_DIR = "/dbfs/tmp"
-os.makedirs(OUT_DIR, exist_ok=True)
-
-def plot_sales_by_category(df):
+def plot_sales_by_category(df, out_dir: str) -> None:
     pdf = df.toPandas()
     if pdf.empty or "Category" not in pdf.columns or "total_sales" not in pdf.columns:
         raise ValueError("Missing required columns for Sales by Category")
-    ax = pdf.sort_values("total_sales", ascending=False).plot(kind="bar", x="Category", y="total_sales")
+    ax = pdf.sort_values("total_sales", ascending=False).plot(
+        kind="bar", x="Category", y="total_sales"
+    )
     ax.set_title("Total Sales by Category")
     ax.set_xlabel("Category")
     ax.set_ylabel("Total Sales")
     plt.tight_layout()
-    out = f"{OUT_DIR}/total_sales_by_category.png"
-    plt.savefig(out); plt.show()
+    out = f"{out_dir}/total_sales_by_category.png"
+    plt.savefig(out)
+    plt.show()
     print(f"✅ Saved: {out}")
 
-def plot_profit_by_region(df):
+
+def plot_profit_by_region(df, out_dir: str) -> None:
     pdf = df.toPandas()
     if pdf.empty or "Region" not in pdf.columns or "total_profit" not in pdf.columns:
         raise ValueError("Missing required columns for Profit by Region")
-    ax = pdf.sort_values("total_profit", ascending=False).plot(kind="bar", x="Region", y="total_profit")
+    ax = pdf.sort_values("total_profit", ascending=False).plot(
+        kind="bar", x="Region", y="total_profit"
+    )
     ax.set_title("Total Profit by Region")
     ax.set_xlabel("Region")
     ax.set_ylabel("Total Profit")
     plt.tight_layout()
-    out = f"{OUT_DIR}/total_profit_by_region.png"
-    plt.savefig(out); plt.show()
+    out = f"{out_dir}/total_profit_by_region.png"
+    plt.savefig(out)
+    plt.show()
     print(f"✅ Saved: {out}")
 
-try:
-    # Query from Gold Layer
-    sales_summary = spark.sql("SELECT Category, Region, total_sales, total_profit FROM gold.sales_summary")
 
-    # Create two plots
-    plot_sales_by_category(sales_summary.select("Category", "total_sales").distinct())
-    plot_profit_by_region(sales_summary.select("Region", "total_profit").distinct())
+def visualize_transformed_data(
+    spark: SparkSession, gold_table: str, out_dir: str
+) -> None:
+    """Read Gold data and generate plots."""
+    os.makedirs(out_dir, exist_ok=True)
 
-    print("🎉 Visualization complete. Open images via:")
-    print("   /files/tmp/total_sales_by_category.png")
-    print("   /files/tmp/total_profit_by_region.png")
+    try:
+        sales_summary = spark.sql(
+            f"SELECT Category, Region, total_sales, total_profit FROM {gold_table}"
+        )
 
-except AnalysisException as e:
-    print(f"SQL query error: {e}")
-except ValueError as e:
-    print(f"Data validation error: {e}")
-except Exception as e:
-    print(f"Unexpected error: {e}")
+        plot_sales_by_category(
+            sales_summary.select("Category", "total_sales").distinct(), out_dir
+        )
+        plot_profit_by_region(
+            sales_summary.select("Region", "total_profit").distinct(), out_dir
+        )
+
+        print("🎉 Visualization complete. Open images via:")
+        path_for_display = out_dir.replace("/dbfs", "/files")
+        print(f"   {path_for_display}/total_sales_by_category.png")
+        print(f"   {path_for_display}/total_profit_by_region.png")
+
+    except AnalysisException as e:
+        print(f"SQL query error: {e}")
+    except ValueError as e:
+        print(f"Data validation error: {e}")
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+
+
+if __name__ == "__main__":
+    spark = SparkSession.builder.appName("Retail_Gold_Visualization").getOrCreate()
+    visualize_transformed_data(
+        spark,
+        gold_table="gold.sales_summary",
+        out_dir="/dbfs/tmp",
+    )


### PR DESCRIPTION
## Summary
- Wrap standalone scripts in functions that accept a SparkSession and input/output paths
- Add `if __name__ == "__main__"` blocks for direct execution
- Parameterize visualization helpers for configurable output directories

## Testing
- `black Codes/01_ETL_Operations.py Codes/02_Delta_Lake_For_Storage.py Codes/03_Spark_SQL_for_DataTransformations.py Codes/04_Visualization_of_Transformed_Data.py`
- `pytest Codes/Test_main.py` *(fails: AssertionError: assert False)*
- `(cd Codes && pytest Test_main.py)` *(fails: AssertionError: assert False)*
- `pylint Codes/main.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d821912c832e9ceff21b9fff8e7d