### PR TITLE
Refactor ETL scripts into parameterized functions

### DIFF
--- a/Codes/01_ETL_Operations.py
+++ b/Codes/01_ETL_Operations.py
@@ -4,26 +4,37 @@ from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, to_date
 import config
 
-# SparkSession is auto-created in Databricks, but you can include this for standalone PySpark
-spark = SparkSession.builder.appName("Retail_ETL").getOrCreate()
 
-# Bronze ingestion
-csv_path = config.CSV_PATH
-raw = (
-    spark.read
-    .option("header", True)
-    .option("inferSchema", True)
-    .csv(csv_path)
-)
+def run_etl(
+    csv_path: str,
+    bronze_table: str,
+    silver_table: str,
+    spark: SparkSession | None = None,
+):
+    """Ingest a CSV file and create Bronze and Silver Delta tables."""
+    spark = spark or SparkSession.builder.appName("Retail_ETL").getOrCreate()
 
-# Quick clean for Silver
-df = (
-    raw.withColumnRenamed("Order ID", "order_id")
-       .withColumn("order_date", to_date(col("Order Date"), "MM/dd/yyyy"))
-       .withColumn("ship_date",  to_date(col("Ship Date"),  "MM/dd/yyyy"))
-       .dropna(subset=["order_id", "order_date"])
-)
+    # fmt: off
+    raw = (
+        spark.read
+        .option("header", True)
+        .option("inferSchema", True)
+        .csv(csv_path)
+    )
+    # fmt: on
 
-# Save Bronze & Silver tables
-raw.write.format("delta").mode("overwrite").saveAsTable(config.BRONZE_TABLE)
-df.write.format("delta").mode("overwrite").saveAsTable(config.SILVER_TABLE)
+    df = (
+        raw.withColumnRenamed("Order ID", "order_id")
+        .withColumn("order_date", to_date(col("Order Date"), "MM/dd/yyyy"))
+        .withColumn("ship_date", to_date(col("Ship Date"), "MM/dd/yyyy"))
+        .dropna(subset=["order_id", "order_date"])
+    )
+
+    raw.write.format("delta").mode("overwrite").saveAsTable(bronze_table)
+    df.write.format("delta").mode("overwrite").saveAsTable(silver_table)
+
+    return df
+
+
+if __name__ == "__main__":
+    run_etl(config.CSV_PATH, config.BRONZE_TABLE, config.SILVER_TABLE)

--- a/Codes/02_Delta_Lake_For_Storage.py
+++ b/Codes/02_Delta_Lake_For_Storage.py
@@ -1,18 +1,38 @@
 from pyspark.sql import SparkSession
 import config
 
-# 02_Delta_Lake_For_Storage (Retail)
-spark = SparkSession.builder.appName("Retail_Delta_Storage").getOrCreate()
 
-silver = spark.table(config.SILVER_TABLE)
+def run_partition(
+    silver_table: str,
+    partitioned_table: str,
+    partition_col: str = "Region",
+    spark: SparkSession | None = None,
+):
+    """Partition the Silver table and write it back as a new Delta table."""
+    # fmt: off
+    spark = spark or SparkSession.builder.appName(
+        "Retail_Delta_Storage"
+    ).getOrCreate()
+    # fmt: on
 
-# partition for scale (pick one: Region or order_date)
-(silver.write
- .format("delta")
- .mode("overwrite")
- .partitionBy("Region")
- .saveAsTable(config.SILVER_PARTITIONED_TABLE))
+    silver = spark.table(silver_table)
 
-# (optional) compaction ops if enabled in your workspace:
-# spark.sql(f"OPTIMIZE {config.SILVER_PARTITIONED_TABLE} ZORDER BY (Category, Region)")
-print(f"✅ Silver partitioned table created: {config.SILVER_PARTITIONED_TABLE}")
+    (
+        silver.write.format("delta")
+        .mode("overwrite")
+        .partitionBy(partition_col)
+        .saveAsTable(partitioned_table)
+    )
+
+    # (optional) compaction ops if enabled in your workspace:
+    # spark.sql(
+    #     f"OPTIMIZE {partitioned_table} ZORDER BY (Category, {partition_col})"
+    # )
+    print(f"✅ Silver partitioned table created: {partitioned_table}")
+
+
+if __name__ == "__main__":
+    run_partition(
+        config.SILVER_TABLE,
+        config.SILVER_PARTITIONED_TABLE,
+    )


### PR DESCRIPTION
## Summary
- wrap ETL, Delta partitioning, and Gold table creation logic in callable functions
- add `if __name__ == '__main__'` entry points using config defaults
- allow paths and table names to be passed as arguments for easier testing

## Testing
- `flake8 Codes/01_ETL_Operations.py Codes/02_Delta_Lake_For_Storage.py Codes/03_Spark_SQL_for_DataTransformations.py`
- `pytest`
- `CSV_PATH="Data/Sample - Superstore.csv" BRONZE_TABLE="bronze.superstore" SILVER_TABLE="silver.superstore" python Codes/01_ETL_Operations.py` *(fails: [DATA_SOURCE_NOT_FOUND] delta)*
- `SILVER_TABLE="silver.superstore" SILVER_PARTITIONED_TABLE="silver.superstore_partitioned" python Codes/02_Delta_Lake_For_Storage.py` *(fails: table not found)*
- `SILVER_PARTITIONED_TABLE="silver.superstore_partitioned" GOLD_TABLE="gold.sales_summary" python Codes/03_Spark_SQL_for_DataTransformations.py` *(fails: table not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e24784d0832e87ed10ba3bbe0d2d