### PR TITLE
Add flake8 linting for Codes directory

### DIFF
--- a/.github/workflows/03_Lint.yml
+++ b/.github/workflows/03_Lint.yml
@@ -8,8 +8,9 @@ on:
       - completed
   
 jobs:
-  ruff:
+  flake8:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - run: pip install flake8
       - run: make lint

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ test:
 	python -m pytest \Codes/Test_*.py
 
 lint:
-	pylint \Codes/main.py
+	flake8 Codes --max-line-length=120 --ignore=E302,E305,E231,E241,E702,F401
 
 all: install format lint test


### PR DESCRIPTION
## Summary
- run flake8 against all Python files under Codes
- ensure CI installs flake8 before linting

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a5e3b960c8832e8b2287dc78a14a04