### PR TITLE
Add tests for visualization functions and config overrides

### DIFF
--- a/Codes/test_config.py
+++ b/Codes/test_config.py
@@ -1,0 +1,27 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the Codes directory is on sys.path so `config` can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "Codes"))
+
+
+def test_environment_overrides(monkeypatch):
+    overrides = {
+        "CSV_PATH": "/tmp/override.csv",
+        "BRONZE_TABLE": "bronze.override",
+        "SILVER_TABLE": "silver.override",
+        "SILVER_PARTITIONED_TABLE": "silver.override_part",
+        "GOLD_TABLE": "gold.override",
+        "OUTPUT_DIR": "/tmp/output_override",
+    }
+    for key, value in overrides.items():
+        monkeypatch.setenv(key, value)
+
+    import config
+    importlib.reload(config)
+
+    for key, value in overrides.items():
+        assert getattr(config, key) == value

--- a/Codes/test_visualization.py
+++ b/Codes/test_visualization.py
@@ -1,0 +1,68 @@
+import ast
+import types
+import sys
+from pathlib import Path
+
+import pytest
+import matplotlib
+matplotlib.use("Agg")
+
+
+def load_viz_module(monkeypatch, tmp_path):
+    codes_dir = Path(__file__).resolve().parents[1] / "Codes"
+    sys.path.insert(0, str(codes_dir))
+
+    # Ensure config picks up overridden OUTPUT_DIR
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    import importlib
+    import config
+    importlib.reload(config)
+
+    file_path = codes_dir / "04_Visualization_of_Transformed_Data.py"
+    source = file_path.read_text()
+    module_ast = ast.parse(source)
+    new_body = []
+    for node in module_ast.body:
+        if isinstance(node, ast.Try):
+            break
+        new_body.append(node)
+    module_ast.body = new_body
+
+    module = types.ModuleType("viz")
+    exec(compile(module_ast, str(file_path), "exec"), module.__dict__)
+    monkeypatch.setattr(module.plt, "show", lambda: None)
+    return module
+
+
+def test_plot_sales_by_category_valid(tmp_path, monkeypatch):
+    viz = load_viz_module(monkeypatch, tmp_path)
+    df = viz.spark.createDataFrame(
+        [("Furniture", 100.0), ("Technology", 200.0)],
+        ["Category", "total_sales"],
+    )
+    viz.plot_sales_by_category(df)
+    assert (Path(viz.OUT_DIR) / "total_sales_by_category.png").exists()
+
+
+def test_plot_sales_by_category_invalid(tmp_path, monkeypatch):
+    viz = load_viz_module(monkeypatch, tmp_path)
+    df = viz.spark.createDataFrame([("Furniture",)], ["Category"])
+    with pytest.raises(ValueError):
+        viz.plot_sales_by_category(df)
+
+
+def test_plot_profit_by_region_valid(tmp_path, monkeypatch):
+    viz = load_viz_module(monkeypatch, tmp_path)
+    df = viz.spark.createDataFrame(
+        [("East", 50.0), ("West", 80.0)],
+        ["Region", "total_profit"],
+    )
+    viz.plot_profit_by_region(df)
+    assert (Path(viz.OUT_DIR) / "total_profit_by_region.png").exists()
+
+
+def test_plot_profit_by_region_invalid(tmp_path, monkeypatch):
+    viz = load_viz_module(monkeypatch, tmp_path)
+    df = viz.spark.createDataFrame([("East",)], ["Region"])
+    with pytest.raises(ValueError):
+        viz.plot_profit_by_region(df)


### PR DESCRIPTION
## Summary
- Add unit tests for `plot_sales_by_category` and `plot_profit_by_region` covering valid and invalid inputs
- Add test ensuring environment variables in `config.py` override default settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5e3bb9e1c832ea1e90a496a799a1a